### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ be allowed over the network, TSIG is recommended.
 On a Debian or Ubuntu system you can install the needed packages:
 
 ```
-$ sudo apt install bind9 bind9utils
+$ sudo apt install bind9 bind9utils dnsutils
 ```
 
 You can then create a TSIG key:


### PR DESCRIPTION
missing dependency will cause the following error:
```
Traceback (most recent call last):
  File "MintCoinPeer2DNS.py", line 114, in <module>
    main(sys.argv)
  File "MintCoinPeer2DNS.py", line 110, in main
    ipv4_peers, ipv6_peers, txt_peers, args.zone)
  File "MintCoinPeer2DNS.py", line 27, in update_domain
    universal_newlines=True) as proc:
  File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1344, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'nsupdate': 'nsupdate'
```
As long as dependency checking is not in, it's worth having it mentioned in the readme